### PR TITLE
更新README文档，添加FetchContent集成说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,32 @@ $ cmake ..
 $ cmake --build .
 ```
 
-* Find and link qBreakpad in your CMake project
+* Find and link qBreakpad in your CMake project (after installation)
 ```cmake
 # In your CMakeLists.txt
 find_package(qBreakpad REQUIRED)
 target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
 ```
 
-* Alternatively, include qBreakpad as a subproject in your CMake project
+* Include qBreakpad as a subproject in your CMake project
 ```cmake
 add_subdirectory(path/to/qBreakpad)
+target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
+```
+
+* Use FetchContent to integrate qBreakpad directly (Modern CMake, recommended)
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  qBreakpad
+  GIT_REPOSITORY https://github.com/feifeizuo/qBreakpad.git
+  GIT_TAG        master  # or specify a specific tag/commit
+)
+
+FetchContent_MakeAvailable(qBreakpad)
+
+# Use the target directly, no need to manually set include paths or link
 target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -25,16 +25,32 @@ $ cmake ..
 $ cmake --build .
 ```
 
-* 在您的CMake项目中查找并链接qBreakpad库
+* 在您的CMake项目中查找并链接qBreakpad库（安装后）
 ```cmake
 # 在您的CMakeLists.txt中添加
 find_package(qBreakpad REQUIRED)
 target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
 ```
 
-* 或者，您可以将qBreakpad作为子项目包含在您的CMake项目中
+* 将qBreakpad作为子项目包含在您的CMake项目中
 ```cmake
 add_subdirectory(path/to/qBreakpad)
+target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
+```
+
+* 使用FetchContent直接集成qBreakpad（现代CMake方式，推荐）
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  qBreakpad
+  GIT_REPOSITORY https://github.com/feifeizuo/qBreakpad.git
+  GIT_TAG        master  # 或指定特定的tag/commit
+)
+
+FetchContent_MakeAvailable(qBreakpad)
+
+# 直接使用目标，无需手动设置include路径或链接
 target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
 ```
 


### PR DESCRIPTION
## 更新内容

基于之前的CMake改进，本次更新了英文和中文README文档，添加了FetchContent集成方式的说明。

### 主要修改
1. 在两个README文档中添加了FetchContent集成方法指南
2. 更新了现有集成方法的描述文字
3. 明确区分了三种集成qBreakpad的方式:
   - 安装后查找并链接
   - 作为子项目包含
   - FetchContent直接集成（新增的现代方式）

### 使用示例
文档现在提供了完整的FetchContent示例代码，帮助用户快速集成:

```cmake
include(FetchContent)

FetchContent_Declare(
  qBreakpad
  GIT_REPOSITORY https://github.com/feifeizuo/qBreakpad.git
  GIT_TAG        master  # or specify a specific tag/commit
)

FetchContent_MakeAvailable(qBreakpad)

# Use the target directly, no need to manually set include paths or link
target_link_libraries(your_target PRIVATE qBreakpad::qBreakpad)
```

这种方式更加简单明了，不需要用户手动设置include路径或链接选项。